### PR TITLE
Updated fluentd version in Gem

### DIFF
--- a/fluent-plugin-swift.gemspec
+++ b/fluent-plugin-swift.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "~> 0.10.0"
+  gem.add_dependency "fluentd", "~> 0.12.0"
   gem.add_dependency "fog", "~> 1.15.0"
   gem.add_dependency "yajl-ruby", "~> 1.0"
   gem.add_dependency "fluent-mixin-config-placeholders", "~> 0.2.0"


### PR DESCRIPTION
@yuuzi41 Can you please review the change.

Reason for change: Plugin installation fails in older version of fluentd. So trying to make it work in latest fluentd version